### PR TITLE
Frontend file ignore list review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__/
 .env
 alembic.ini
 
+# Next.js frontend関連の除外設定（実際に存在するもののみ）
+frontend/node_modules/
+frontend/.next/
+


### PR DESCRIPTION
Update .gitignore to exclude only existing frontend build artifacts and dependencies.

Refines frontend exclusions in .gitignore to only include `node_modules/` and `.next/`, based on actual directory content, removing entries for non-existent files like `.env`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1f68e4e-069d-4d51-8f0e-b3882b15b47f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1f68e4e-069d-4d51-8f0e-b3882b15b47f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>