### PR TITLE
Fix the remaining error

### DIFF
--- a/app/schemas/openai.py
+++ b/app/schemas/openai.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
  
 class GenerateTweetResponse(BaseModel):
+    tweet_text: str
     commit_message: str
-    tweet_draft: str 
+    repository: str 

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -18,8 +18,9 @@ def test_generate_tweet(monkeypatch):
     app.dependency_overrides[get_generate_tweet_with_openai] = lambda: mock_generate_tweet_with_openai
     client = TestClient(app)
 
-    response = client.post("/api/generate_tweet", json={"repository": "user/repo"})
+    response = client.post("/api/generate_tweet", json={"repository": "user/repo", "language": "ja"})
     assert response.status_code == 200
     data = response.json()
     assert data["commit_message"] == "fix: バグ修正"
-    assert data["tweet_draft"].startswith("リポジトリuser/repo") 
+    assert data["tweet_text"].startswith("リポジトリuser/repo")
+    assert data["repository"] == "user/repo" 


### PR DESCRIPTION
Fix Pydantic validation error by aligning `GenerateTweetResponse` schema with API response.

The `GenerateTweetResponse` schema was incorrectly defined with `tweet_draft` while the API was returning `tweet_text`, leading to a Pydantic validation error and preventing the generated tweet from being displayed on the frontend. This PR updates the schema and corresponding tests to use `tweet_text` and include the `repository` field.

---
<a href="https://cursor.com/background-agent?bcId=bc-94c06d17-b931-4392-a02f-737dc59adcd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94c06d17-b931-4392-a02f-737dc59adcd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>